### PR TITLE
Fix build failure in RISCV deepin

### DIFF
--- a/configure
+++ b/configure
@@ -57,7 +57,7 @@ fi
 
 BINDIR="$EXECPREFIX/bin"
 SBINDIR="$EXECPREFIX/sbin"
-MANDIR="$PREFIX/man"
+MANDIR="$PREFIX/share/man"
 
 echo "Directories: $BINDIR $SBINDIR $MANDIR "
 
@@ -122,7 +122,7 @@ EOF
 
 if [ x"$CXX" = x ]; then
     echo -n 'Looking for a C++ compiler... '
-    for TRY in egcs gcc g++ CC c++ cc; do
+    for TRY in egcs g++ gcc CC c++ cc; do
        (
            $TRY __conftest.cc -o __conftest || exit 1;
            ./__conftest || exit 1;

--- a/telnet/main.cc
+++ b/telnet/main.cc
@@ -51,6 +51,7 @@ char main_rcsid[] =
 #include "externs.h"
 #include "defines.h"
 #include "proto.h"
+#include <cstdlib>
 
 /*
  * Initialize variables.

--- a/telnet/netlink.cc
+++ b/telnet/netlink.cc
@@ -11,6 +11,7 @@
 #include "netlink.h"
 #include "proto.h"
 #include "ring.h"
+#include <cstring>
 
 /* In Linux, this is an enum */
 #if defined(__linux__) || defined(IPPROTO_IP)

--- a/telnet/network.cc
+++ b/telnet/network.cc
@@ -48,7 +48,7 @@ char net_rcsid[] =
 #include "externs.h"
 #include "proto.h"
 #include "netlink.h"
-
+#include <cstdlib>
 ringbuf netoring;
 ringbuf netiring;
 

--- a/telnet/terminal.cc
+++ b/telnet/terminal.cc
@@ -45,6 +45,8 @@ char terminal_rcsid[] =
 #include <signal.h>
 #include <errno.h>
 #include <stdio.h>
+#include <cstring>
+#include <cstdlib>
 
 #include "ring.h"
 #include "defines.h"

--- a/telnet/utilities.cc
+++ b/telnet/utilities.cc
@@ -47,6 +47,8 @@ char util_rcsid[] =
 #include <sys/socket.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "ring.h"
 #include "defines.h"


### PR DESCRIPTION
* Teach `configure` to use g++ as its C++ compiler first.
* Fix wrong manpage directory.
* Add missing includes.

```
I have read the CLA Document and I hereby sign the CLA.
```