### PR TITLE
Fix build failure in RISCV deepin

### DIFF
--- a/debian/patches/add-missing-lib.patch
+++ b/debian/patches/add-missing-lib.patch
@@ -1,0 +1,19 @@
+Description: Link with the missing ncurses library
+Author: Xiangwei Gui <yuemeng.gui@gmail.com>
+--- a/telnet/CMakeLists.txt
++++ b/telnet/CMakeLists.txt
+@@ -1,4 +1,5 @@
+-
++find_package(Curses REQUIRED)
++include_directories(${CURSES_INCLUDE_DIR})
+ set(
+     CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+     -DUSE_TERMIO \
+@@ -20,6 +21,7 @@
+     tn3270.cc
+     utilities.cc
+ )
++target_link_libraries(telnet.netkit ${CURSES_LIBRARIES})
+ install(
+     TARGETS telnet.netkit
+     DESTINATION ${BIN_DIR}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -15,3 +15,4 @@
 use-cmake-as-buildsystem.patch
 use-cmake-as-buildsystem-debian-extras.patch
 telnet-netwritebuf-fix.diff
+add-missing-lib.patch


### PR DESCRIPTION
ncurses is not linked with telnet by default, which triggered an undefined
symbol error. This patch fixes this by explicitly telling cmake about about
to do that.